### PR TITLE
Repro https://github.com/microsoft/TypeScript/issues/47279

### DIFF
--- a/.yarn/patches/typescript-npm-4.5.4-2da9ac18bd
+++ b/.yarn/patches/typescript-npm-4.5.4-2da9ac18bd
@@ -1,0 +1,18 @@
+diff --git a/lib/tsserver.js b/lib/tsserver.js
+index 028346841ea0dcf8063bcd652ddc114182470a63..bff4cc5d68c8ac408d45f18eacbaa9dc87aac35b 100644
+--- a/lib/tsserver.js
++++ b/lib/tsserver.js
+@@ -174399,7 +174399,12 @@ var ts;
+             // changes for large reference sets? If so, do we want
+             // to increase the chunk size or decrease the interval
+             // time dynamically to match the large reference set?
+-            sys.defaultWatchFileKind = function () { return ts.WatchFileKind.FixedChunkSizePolling; };
++
++            // REPRO STEPS:
++            // run yarn install
++            // Open a.ts in VSCode
++            // If necessary, restart the TS Server, and look for this log
++            sys.defaultWatchFileKind = function () { ts.sysLog("The default watch file kind is being returned. Probably an error?"); return ts.WatchFileKind.FixedChunkSizePolling; };
+             /* eslint-disable no-restricted-globals */
+             sys.setTimeout = setTimeout;
+             sys.clearTimeout = clearTimeout;

--- a/a.ts
+++ b/a.ts
@@ -1,3 +1,5 @@
+import {bar} from './b'
+
 function foo() {
-    console.log('hi there');
+    bar();
 }

--- a/b.ts
+++ b/b.ts
@@ -1,0 +1,3 @@
+export function bar() {
+    console.log('hi there');
+}

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "devDependencies": {
         "typescript": "4.5.4"
     },
-    "packageManager": "yarn@3.1.1"
+    "packageManager": "yarn@3.1.1",
+    "resolutions": {
+        "typescript@4.5.4": "patch:typescript@npm:4.5.4#.yarn/patches/typescript-npm-4.5.4-2da9ac18bd"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,13 +15,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.5.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@npm:4.5.4#.yarn/patches/typescript-npm-4.5.4-2da9ac18bd::locator=typescript_repros%40workspace%3A.":
   version: 4.5.4
-  resolution: "typescript@patch:typescript@npm%3A4.5.4#~builtin<compat/typescript>::version=4.5.4&hash=493e53"
+  resolution: "typescript@patch:typescript@npm%3A4.5.4#.yarn/patches/typescript-npm-4.5.4-2da9ac18bd::version=4.5.4&hash=3a2a4a&locator=typescript_repros%40workspace%3A."
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2e488dde7d2c4a2fa2e79cf2470600f8ce81bc0563c276b72df8ff412d74456ae532ba824650ae936ce207440c79720ddcfaa25e3cb4477572b8534fa4e34d49
+  checksum: 23bdff674284594464517a6688e13ea84b26cecae4200277e43eb6f284bcfbfb9bb456884a311db5196f5dd3ec863dddf0897a62e29edeebe3aab201d2ebbe2a
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@patch%3Atypescript@npm%3A4.5.4%23.yarn/patches/typescript-npm-4.5.4-2da9ac18bd%3A%3Alocator=typescript_repros%2540workspace%253A.#~builtin<compat/typescript>":
+  version: 4.5.4
+  resolution: "typescript@patch:typescript@patch%3Atypescript@npm%253A4.5.4%23.yarn/patches/typescript-npm-4.5.4-2da9ac18bd%3A%3Aversion=4.5.4&hash=3a2a4a&locator=typescript_repros%2540workspace%253A.#~builtin<compat/typescript>::version=4.5.4&hash=493e53"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 0ab1a4defab8417f0ca0c7899e18577ba92d2a5adb3a22dce67aa27ce191cd49ad44465303d12379c2869cddb0e0df814c443f5a90084aae60f3c46fd614bdd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR demonstrates a bug in tsserver where it is not respecting watchOptions.

In short, file watches for the files included in this simple program are falling back to the default file watch option.

Repro steps:
1. Install yarn, if you have not. npm install -g yarn
2. Checkout this branch
3. Run yarn install
4. Open this folder in VSCode
5. Open a.ts
6. Open TS Server Log
7. Look for log lines like this: (you may need to restart TS Server if it doesn't repro)

```
Info 26   [19:59:21.445] FileWatcher:: Added:: WatchInfo: /Users/marc.celani/h/source/TypeScriptRepros/b.ts 500 undefined WatchType: Closed Script info
Info 27   [19:59:21.445] The default watch file kind is being returned. Probably an error?
```

The expectation is that it should be using the FSEvents watch.